### PR TITLE
update for dash 2.5.1

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,15 @@
+"""
+ CREDIT: This code is adapted for `pages`  based on Nader Elshehabi's  article:
+   https://dev.to/naderelshehabi/securing-plotly-dash-using-flask-login-4ia2
+   https://github.com/naderelshehabi/dash-flask-login
+
+For other Authentication options see:
+  Dash Enterprise:  https://dash.plotly.com/authentication#dash-enterprise-auth
+  Dash Basic Auth:  https://dash.plotly.com/authentication#basic-auth
+
+"""
+
+
 import os
 
 from flask import Flask
@@ -5,21 +17,18 @@ from flask_login import login_user, LoginManager, UserMixin, logout_user, curren
 
 import dash
 from dash import dcc, html, Input, Output, State
-import dash_labs as dl
-
-# CREDIT: This code is adapted for the dash-labs `pages` plugin based on Nader Elshehabi's  article:
-#   https://dev.to/naderelshehabi/securing-plotly-dash-using-flask-login-4ia2
-#   https://github.com/naderelshehabi/dash-flask-login
 
 
 # Exposing the Flask Server to enable configuring it for logging in
 server = Flask(__name__)
 app = dash.Dash(
-    __name__,
-    server=server,
-    plugins=[dl.plugins.pages],
-    suppress_callback_exceptions=True,
+    __name__, server=server, use_pages=True, suppress_callback_exceptions=True
 )
+
+# Keep this out of source code repository - save in a file or a database
+#  passwords should be encrypted
+VALID_USERNAME_PASSWORD = {"test": "test", "hello": "world"}
+
 
 # Updating the Flask Server configuration with Secret Key to encrypt the user session cookie
 server.config.update(SECRET_KEY=os.getenv("SECRET_KEY"))
@@ -47,31 +56,26 @@ def load_user(username):
 
 app.layout = html.Div(
     [
-        dcc.Location(id="url-login"),
+        dcc.Location(id="url"),
         dcc.Store(id="login-status", storage_type="session"),
         html.Div(id="user-status-header"),
         html.Hr(),
-        dl.plugins.page_container,
+        dash.page_container,
     ]
 )
 
 
 @app.callback(
-    Output("login-status", "data"),
     Output("user-status-header", "children"),
-    Input("url-login", "pathname"),
+    Input("url", "pathname"),
 )
 def update_authentication_status(path):
-    #  Updates the login link in the header and the dcc.Store with the user authentication status
-
     logged_in = current_user.is_authenticated
     if path == "/logout" and logged_in:
         logout_user()
     if logged_in:
-        link = dcc.Link("logout", href="/logout")
-    else:
-        link = dcc.Link("login", href="/login")
-    return logged_in, link
+        return dcc.Link("logout", href="/logout")
+    return dcc.Link("login", href="/login")
 
 
 @app.callback(
@@ -83,10 +87,12 @@ def update_authentication_status(path):
 )
 def login_button_click(n_clicks, username, password):
     if n_clicks > 0:
-        if username == "test" and password == "test":
+        if VALID_USERNAME_PASSWORD.get(username) is None:
+            return "Invalid username"
+        if VALID_USERNAME_PASSWORD.get(username) == password:
             login_user(User(username))
             return "Login Successful"
-        return "Incorrect username or password"
+        return "Incorrect  password"
 
 
 if __name__ == "__main__":

--- a/pages/login.py
+++ b/pages/login.py
@@ -16,3 +16,14 @@ layout = html.Div(
         dcc.Link("Home", href="/"),
     ]
 )
+
+"""
+If you get this error message:
+    dash.exceptions.NoLayoutException: No layout in module pages.login in dash.page_registry
+
+Then register the page like this:
+
+dash.register_page(__name__, layout=layout)
+
+For more info see: https://github.com/AnnMarieW/dash-multi-page-app-demos/issues/1
+"""

--- a/pages/page-1.py
+++ b/pages/page-1.py
@@ -23,4 +23,4 @@ layout = html.Div(
 
 @callback(Output("page-1-content", "children"), Input("page-1-dropdown", "value"))
 def page_1_dropdown(value):
-    return 'You have selected "{}"'.format(value)
+    return f'You have selected "{value}"'

--- a/pages/page-2.py
+++ b/pages/page-2.py
@@ -1,6 +1,7 @@
 import dash
 from dash import html, dcc, Output, Input, callback
 from pages.login import layout as login
+from flask_login import current_user
 
 dash.register_page(__name__)
 
@@ -23,13 +24,13 @@ logged_in_layout = html.Div(
 )
 
 
-@callback(Output("page-2-auth-content", "children"), Input("login-status", "data"))
-def authenticate(logged_in):
-    if logged_in:
+@callback(Output("page-2-auth-content", "children"), Input("url", "href"))
+def authenticate(_):
+    if current_user.is_authenticated:
         return logged_in_layout
     return login
 
 
 @callback(Output("page-2-content", "children"), Input("page-2-radios", "value"))
 def page_2_radios(value):
-    return 'You have selected "{}"'.format(value)
+    return f'You have selected "{value}"'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-dash
+dash==2.5.1
 ldap3
 flask-login
 python-dotenv
-dash-labs


### PR DESCRIPTION
Update for using pages with dash 2.5.1 rather than the plug-in in dash labs
Eliminates the use of dcc.Store for login status